### PR TITLE
fix: use NODE_AUTH_TOKEN in .yarnrc.yml for setup-node@v7 compatibility

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,7 +3,7 @@ nodeLinker: node-modules
 npmScopes:
   navikt:
     npmAlwaysAuth: true
-    npmAuthToken: "${NPM_AUTH_TOKEN:-}"
+    npmAuthToken: "${NODE_AUTH_TOKEN:-}"
     npmRegistryServer: "https://npm.pkg.github.com"
 
 # Sikkerhetstiltak


### PR DESCRIPTION
## Problem
`actions/setup-node@v7` removed the dummy `NODE_AUTH_TOKEN` export and no longer recognizes `NPM_AUTH_TOKEN`. Yarn berry reads auth directly from `.yarnrc.yml`, so the token reference must match the env var that `setup-node` sets.

## Change
Rename `NPM_AUTH_TOKEN` → `NODE_AUTH_TOKEN` in `.yarnrc.yml`.

Same fix applied in navikt/mine-aap.